### PR TITLE
ORM

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,9 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import pathlib
 
+source_dir = pathlib.Path(__file__).parent
 
 # -- Project information -----------------------------------------------------
 
@@ -47,6 +49,12 @@ extensions = [
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
+
+# The master toctree document.
+master_doc = "index"
+bibtex_bibfiles = [
+    str(p.relative_to(source_dir)) for p in (source_dir / "refs").glob("*.bib")
+]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -1,0 +1,10 @@
+ORM with SQLAlchemy
+===================
+
+To find more infos about querying:
+
+https://docs.sqlalchemy.org/en/13/orm/tutorial.html#querying
+
+Right below there are all the operators available for the query:
+
+https://docs.sqlalchemy.org/en/13/orm/tutorial.html#common-filter-operators

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,12 @@ def setup_package():
         ],
         install_requires=[
             "ipython",
+            "SQLAlchemy",
             "numpy",
             "pandas",
             "jinja2",
             "rich",
             "pyyaml",
-            "tinydb~=4.1",
             "human_dates2",
         ],
         entry_points={

--- a/src/banana/benchmark/runner.py
+++ b/src/banana/benchmark/runner.py
@@ -307,7 +307,7 @@ class BenchmarkRunner:
             "o_hash": o["hash"],
             "pdf": pdf.set().name,
             "external": self.external,
-            "log": log_record,
+            "log": log_record.to_document(),
         }
         raw_records, df = sql.prepare_records(default_log, [record])
         sql.insertnew(session, db.Log, df)

--- a/src/banana/benchmark/runner.py
+++ b/src/banana/benchmark/runner.py
@@ -15,7 +15,7 @@ import rich.markdown
 
 from .. import toy
 
-from ..data import theories, sql
+from ..data import theories, sql, db
 
 
 def get_pdf(pdf_name):
@@ -41,7 +41,9 @@ def get_pdf(pdf_name):
         # is the set installed? if not do it now
         if pdf_name not in lhapdf.availablePDFSets():
             print(f"PDFSet {pdf_name} is not installed! Installing now via lhapdf ...")
-            res = subprocess.run(["lhapdf", "get", pdf_name], check=True,capture_output=True)
+            res = subprocess.run(
+                ["lhapdf", "get", pdf_name], check=True, capture_output=True
+            )
             if len(res.stdout) == 0:
                 raise ValueError("lhapdf could not install the set!")
             print(f"{pdf_name} installed.")
@@ -71,16 +73,8 @@ class BenchmarkRunner:
 
     console = rich.console.Console()
 
-    @abc.abstractstaticmethod
-    def init_ocards(conn):
-        """
-        Create o-card table.
-
-        Parameters
-        ----------
-            conn : sqlite3.Connection
-                DB connection
-        """
+    db_base_cls = None
+    """Base clase that describes db schema"""
 
     @abc.abstractstaticmethod
     def load_ocards(conn, ocard_updates):
@@ -181,13 +175,10 @@ class BenchmarkRunner:
         # check the existence before opening, as sqlite creates an empty file by default
         init = not pathlib.Path(db_path).exists()
         conn = sqlite3.connect(db_path)
+        engine = db.engine(db_path)
         if init:
-            with conn:
-                conn.execute(sql.create_table("theories", theories.default_card))
-                conn.execute(sql.create_table("cache", default_cache, False))
-                conn.execute(sql.create_table("logs", default_log))
-            self.init_ocards(conn)
-            # init log
+            __import__("ipdb").set_trace()
+            db.create_db(self.db_base_cls, engine)
         return conn
 
     def load_external(self, conn, t, o, pdf):

--- a/src/banana/benchmark/runner.py
+++ b/src/banana/benchmark/runner.py
@@ -199,14 +199,14 @@ class BenchmarkRunner:
             ext : dict
                 exernal result if available
         """
-        ext = session.query(
+        ext = session.query(db.Cache).filter(
             db.Cache.t_hash == t["hash"],
             db.Cache.o_hash == o["hash"],
             db.Cache.pdf == pdf.set().name,
             db.Cache.external == self.external,
         )
         # if not found or multiple found, ext.one() will raise an Error
-        return pickle.loads(ext.one())
+        return pickle.loads(ext.one().result)
 
     def insert_external(self, session, t, o, pdf):
         """

--- a/src/banana/data/__init__.py
+++ b/src/banana/data/__init__.py
@@ -5,7 +5,7 @@ Module to collect utilites to help with the data generation:
 import itertools
 
 
-def power_set(inp):
+def cartesian_product(inp):
     """
     Compute the power set of a dictionary.
 

--- a/src/banana/data/db.py
+++ b/src/banana/data/db.py
@@ -8,9 +8,10 @@ so we can keep declaring a size for fields where it matters.
 Same considerations apply to datetime, with the further gain that SQLite it's
 storing as he wish but able to use some dedicated functions.
 """
+import pathlib
 
 import sqlalchemy
-from sqlalchemy import Column, Integer, String, Text, DateTime
+from sqlalchemy import Column, Integer, Float, String, Text, DateTime
 from sqlalchemy.sql import func
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -29,7 +30,48 @@ Base = declarative_base(cls=MyBase)
 
 class Theory(Base):
     __tablename__ = "theories"
-    pto = Column(Integer)
+    ID = Column(Integer)
+    PTO = Column(Integer)
+    CKM = Column(Text)
+    Comments = Column(Text)
+    DAMP = Column(Integer)
+    EScaleVar = Column(Integer)
+    FNS = Column(Text)
+    GF = Column(Float)
+    HQ = Column(Text)
+    IC = Column(Integer)
+    MP = Column(Float)
+    MW = Column(Float)
+    MZ = Column(Float)
+    MaxNfAs = Column(Integer)
+    MaxNfPdf = Column(Integer)
+    ModEv = Column(Text)
+    NfFF = Column(Integer)
+    Q0 = Column(Float)
+    QED = Column(Integer)
+    Qedref = Column(Float)
+    Qmb = Column(Float)
+    Qmc = Column(Float)
+    Qmt = Column(Float)
+    Qref = Column(Float)
+    SIN2TW = Column(Float)
+    SxOrd = Column(Text)
+    SxRes = Column(Integer)
+    TMC = Column(Integer)
+    XIF = Column(Float)
+    XIR = Column(Float)
+    alphaqed = Column(Float)
+    alphas = Column(Float)
+    global_nx = Column(Integer)
+    kDISbThr = Column(Float)
+    kDIScThr = Column(Float)
+    kDIStThr = Column(Float)
+    kbThr = Column(Float)
+    kcThr = Column(Float)
+    ktThr = Column(Float)
+    mb = Column(Float)
+    mc = Column(Float)
+    mt = Column(Float)
 
 
 # mixin
@@ -50,10 +92,18 @@ class Log(CalcResult, Base):
     log = Column(Text)
 
 
-# Create an engine that stores data in the local directory's
-# sqlalchemy_example.db file.
-engine = sqlalchemy.create_engine("sqlite:///sqlalchemy_example.db")
+def engine(path):
+    # Create an engine that stores data in the local directory's
+    # sqlalchemy_example.db file.
+    path = pathlib.Path(path).absolute()
+    return sqlalchemy.create_engine(f"sqlite:///{str(path)}")
 
-# Create all tables in the engine. This is equivalent to "Create Table"
-# statements in raw SQL.
-Base.metadata.create_all(engine)
+
+def create_db(base_cls, engine):
+    # Create all tables in the engine. This is equivalent to "Create Table"
+    # statements in raw SQL.
+    base_cls.metadata.create_all(engine)
+
+
+if __name__ == "__main__":
+    create_db(Base, engine("sqlalchemy_example.db"))

--- a/src/banana/data/db.py
+++ b/src/banana/data/db.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+from . import sql
+
+
+class TableObject:
+    def __init__(self, add_hash=True, prototype=None):
+        if prototype is None:
+            prototype = {}
+
+        self.fields = {"uid": "INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE"}
+        # add explicit hash?
+        if add_hash:
+            self.fields["hash"] = "BLOB UNIQUE"
+
+        # collect fields
+        for k, v in prototype.items():
+            self.fields[k] = sql.mapping[type(v)]
+
+    @property
+    def sqlfields(self):
+        return [f"{k} {v}" for k, v in self.fields.items()]
+
+
+class Theory(TableObject):
+    name = "theory"
+    pass
+
+
+class OCard(abc.ABC):
+    pass
+
+
+class Cache:
+    pass
+
+
+class Log:
+    pass

--- a/src/banana/data/db.py
+++ b/src/banana/data/db.py
@@ -103,7 +103,3 @@ def create_db(base_cls, engine):
     # Create all tables in the engine. This is equivalent to "Create Table"
     # statements in raw SQL.
     base_cls.metadata.create_all(engine)
-
-
-if __name__ == "__main__":
-    create_db(Base, engine("sqlalchemy_example.db"))

--- a/src/banana/data/db.py
+++ b/src/banana/data/db.py
@@ -1,41 +1,59 @@
 # -*- coding: utf-8 -*-
+"""
+Actually using ``String`` it's pointless, since SQLite has only one text type
+and it is ``TEXT``, and the maximum length is coherently ignored by SQLite.
+Nevertheless the information is stored in the DB, even if the DBMS won't use it,
+so we can keep declaring a size for fields where it matters.
 
-import abc
+Same considerations apply to datetime, with the further gain that SQLite it's
+storing as he wish but able to use some dedicated functions.
+"""
 
-from . import sql
-
-
-class TableObject:
-    def __init__(self, add_hash=True, prototype=None):
-        if prototype is None:
-            prototype = {}
-
-        self.fields = {"uid": "INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE"}
-        # add explicit hash?
-        if add_hash:
-            self.fields["hash"] = "BLOB UNIQUE"
-
-        # collect fields
-        for k, v in prototype.items():
-            self.fields[k] = sql.mapping[type(v)]
-
-    @property
-    def sqlfields(self):
-        return [f"{k} {v}" for k, v in self.fields.items()]
+import sqlalchemy
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from sqlalchemy.sql import func
+from sqlalchemy.ext.declarative import declarative_base
 
 
-class Theory(TableObject):
-    name = "theory"
-    pass
+class MyBase:
+    uid = Column(Integer, primary_key=True, unique=True)
+    hash = Column(String(64), unique=True)
+    # TODO: should we use `func.utcnow`?
+    # https://stackoverflow.com/a/33532154/8653979
+    ctime = Column(DateTime(timezone=True), server_default=func.now())
+    mtime = Column(DateTime(timezone=True), onupdate=func.now())
 
 
-class OCard(abc.ABC):
-    pass
+Base = declarative_base(cls=MyBase)
 
 
-class Cache:
-    pass
+class Theory(Base):
+    __tablename__ = "theories"
+    pto = Column(Integer)
 
 
-class Log:
-    pass
+# mixin
+class CalcResult:
+    external = Column(Text)
+    t_hash = Column(String(64))
+    o_hash = Column(String(64))
+    pdf = Column(Text)
+
+
+class Cache(CalcResult, Base):
+    __tablename__ = "cache"
+    result = Column(Text)
+
+
+class Log(CalcResult, Base):
+    __tablename__ = "logs"
+    log = Column(Text)
+
+
+# Create an engine that stores data in the local directory's
+# sqlalchemy_example.db file.
+engine = sqlalchemy.create_engine("sqlite:///sqlalchemy_example.db")
+
+# Create all tables in the engine. This is equivalent to "Create Table"
+# statements in raw SQL.
+Base.metadata.create_all(engine)

--- a/src/banana/data/dfdict.py
+++ b/src/banana/data/dfdict.py
@@ -37,14 +37,14 @@ class DFdict(dict):
                 self.msgs.append(msg)
         self.msgs.append(end)
 
-    # def __setitem__(self, key, value):
-    #     self.print(key)
-    #     self.print(value)
-    #     self.print()
-    #     super().__setitem__(key, value)
+    def __setitem__(self, key, value):
+        self.print(key)
+        self.print(value)
+        self.print()
+        super().__setitem__(key, value)
 
-    # def __repr__(self):
-    #    return "".join([str(x) for x in self.msgs])
+    def __repr__(self):
+        return "".join([str(x) for x in self.msgs])
 
     def to_document(self):
         """
@@ -59,4 +59,30 @@ class DFdict(dict):
         for k, v in self.items():
             d[k] = v.to_dict(orient="records")
 
+        d["__msgs__"] = self.msgs
+
         return d
+
+    @classmethod
+    def from_document(cls, d):
+        """
+        Load dataframes from a previous dictionary dump
+
+        Parameters
+        ----------
+        d : dict
+            raw dictionary, containing a dump of a DFdict object
+
+        Returns
+        -------
+        DFdict
+            the loaded DFdict
+        """
+        dfd = cls()
+        for k, v in d.items():
+            dfd[k] = v
+
+        del dfd["__msgs__"]
+        dfd.msgs = d["__msgs__"]
+
+        return dfd

--- a/src/banana/data/sql.py
+++ b/src/banana/data/sql.py
@@ -220,9 +220,10 @@ def insertnew(session, table, df):
     df : pandas.DataFrame
         dataframe all records
     """
-    hashes = session.query(table.hash).all()
+    # TODO: why the hash field is a 1-tuple?
+    hashes = [h[0] for h in session.query(table.hash).all()]
     new_records = df[~df["hash"].isin(hashes)]
-    insertmany(session, table, df)
+    insertmany(session, table, new_records)
 
 
 class HashError(KeyError):

--- a/src/banana/data/sql.py
+++ b/src/banana/data/sql.py
@@ -21,7 +21,7 @@ Mapping of Python types to SQLite types.
 """
 
 
-def create_table(name, obj, add_hash=True):
+def create_table(table):
     """
     SQL command for creating the table
 
@@ -39,16 +39,9 @@ def create_table(name, obj, add_hash=True):
         tmpl : str
             SQL command
     """
-    tmpl = f"CREATE TABLE {name} (\n"
-    fields = ["uid INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE"]
-    # add explicit hash?
-    if add_hash:
-        fields.append("hash BLOB UNIQUE")
-    # collect fields
-    for k, v in obj.items():
-        fields.append(f"{k} {mapping[type(v)]}")
+    tmpl = f"CREATE TABLE {table.name} (\n"
     # collect
-    tmpl += ",\n".join(fields)
+    tmpl += ",\n".join(table.fields)
     tmpl += "\n);"
     return tmpl
 

--- a/src/banana/data/sql.py
+++ b/src/banana/data/sql.py
@@ -8,20 +8,6 @@ import pandas as pd
 
 from banana.data import dfdict
 
-mapping = {
-    int: "INTEGER",
-    float: "REAL",
-    str: "TEXT",
-    dict: "BLOB",
-    list: "BLOB",
-    bytes: "BLOB",
-    bool: "BOOL",
-    dfdict.DFdict: "BLOB",
-}
-"""
-Mapping of Python types to SQLite types.
-"""
-
 
 def serialize(data):
     """
@@ -123,25 +109,6 @@ def prepare_records(base, updates):
         document["hash"] = hashed_record[-1]
         records.append(hashed_record)
     return (documents, pd.DataFrame(records, columns=(list(base.keys()) + ["hash"])))
-
-
-def question_args(seq):
-    """
-    Join sufficient ?s (Not only 3)
-
-    See: https://de.wikipedia.org/wiki/Die_drei_%3F%3F%3F
-
-    Parameters
-    ----------
-        seq : list
-            arguments
-
-    Returns
-    -------
-        str
-            sql template
-    """
-    return "(" + ",".join(list("?" * len(seq))) + ")"
 
 
 def insertmany(session, table, df):

--- a/src/banana/data/sql.py
+++ b/src/banana/data/sql.py
@@ -93,6 +93,8 @@ def deserialize(data, fields):
     for f, el in zip(fields, data):
         if isinstance(el, bytes) and "hash" not in f:
             obj[f] = pickle.loads(el)
+            if isinstance(obj[f], dict) and "__msgs__" in obj[f]:
+                obj[f] = dfdict.DFdict.from_document(obj[f])
         else:
             obj[f] = el
     return obj

--- a/src/banana/data/sql.py
+++ b/src/banana/data/sql.py
@@ -23,44 +23,19 @@ Mapping of Python types to SQLite types.
 """
 
 
-def create_table(table):
-    """
-    SQL command for creating the table
-
-    Parameters
-    ----------
-        name : str
-            table name
-        obj : dict
-            column-names to example values mapping
-        add_hash : bool
-            add hash field?
-
-    Returns
-    -------
-        tmpl : str
-            SQL command
-    """
-    tmpl = f"CREATE TABLE {table.name} (\n"
-    # collect
-    tmpl += ",\n".join(table.fields)
-    tmpl += "\n);"
-    return tmpl
-
-
 def serialize(data):
     """
     Eventually turn some elements into their binary representation.
 
     Parameters
     ----------
-        data : dict
-            raw data
+    data : dict
+        raw data
 
     Returns
     -------
-        ndata : list
-            improved data
+    ndata : list
+        improved data
     """
     blobbed_types = [list, dict, dfdict.DFdict]
     sorted_data = dict(sorted(data.items()))
@@ -136,7 +111,7 @@ def add_hash(record):
             data + hash
     """
     h = hashlib.sha256(pickle.dumps(record))
-    return (*record, h.digest())
+    return (*record, h.digest().hex())
 
 
 def prepare_records(base, updates):
@@ -257,7 +232,7 @@ def select_hash(conn, table, bin_hash_partial):
     with conn:
         elems = conn.execute(
             f"SELECT * FROM {table} WHERE SUBSTR(hash,1,{len(bin_hash_partial)}) = ?",
-            [sqlite3.Binary(bin_hash_partial)],
+            [bin_hash_partial],
         )
         available = elems.fetchall()
     # too much?

--- a/src/banana/data/theories.py
+++ b/src/banana/data/theories.py
@@ -4,6 +4,7 @@ import pathlib
 import yaml
 
 from . import sql
+from . import db
 
 _here = pathlib.Path(__file__).parent
 
@@ -14,9 +15,9 @@ with open(_here / "theory_template.yaml") as f:
 default_card = dict(sorted(default_card.items()))
 
 # db interface
-def load(conn, updates):
+def load(session, updates):
     # add hash
-    raw_records, rf = sql.prepare_records(default_card, updates)
+    raw_records, df = sql.prepare_records(default_card, updates)
     # insert new ones
-    sql.insertnew(conn, "theories", rf)
+    sql.insertnew(session, db.Theory, df)
     return raw_records

--- a/src/banana/navigator/__init__.py
+++ b/src/banana/navigator/__init__.py
@@ -3,7 +3,7 @@ import inspect
 import IPython
 from traitlets.config.loader import Config
 
-from .navigator import NavigatorApp, t, o, c, l
+from .navigator import NavigatorApp, t, o, c, l, table_objects
 from .utils import compare_dicts
 
 help_vars = f"""t = "{t}" -> query theories

--- a/src/banana/navigator/navigator.py
+++ b/src/banana/navigator/navigator.py
@@ -137,11 +137,11 @@ class NavigatorApp(abc.ABC):
             input_data = self.get(table)
         data = []
         for el in input_data:
-            # obj = {"hash": el["hash"].hex()[:6]}
+            # obj = {"hash": el["hash"][:6]}
             obj = {"uid": el["uid"]}
             for k, v in el.items():
                 if "hash" in k:
-                    obj[k] = v.hex()[:self.hash_len]
+                    obj[k] = v[: self.hash_len]
             self.__getattribute__(f"fill_{self.table_name(table)}")(el, obj)
             # dt = datetime.fromisoformat(el["_created"])
             # obj["created"] = human_dates(dt)

--- a/src/banana/navigator/table_manager.py
+++ b/src/banana/navigator/table_manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ..data import sql
+from ..data import sql, db
 
 
 class TableManager:
@@ -11,18 +11,18 @@ class TableManager:
     ----------
     session : sqlalchemy.orm.session.Session
         DB ORM session
-    table_name : str
-        table name
+    table_object : sqlalchemy.ext.declarative.api.DeclarativeMeta
+        table object
     """
 
-    def __init__(self, session, table_name):
+    def __init__(self, session, table_object):
         self.session = session
-        self.table_name = table_name
+        self.table_object = table_object
 
     def truncate(self):
         """Truncate all elements."""
         # deny rest
-        if self.table_name != "logs":
+        if self.table_object != db.Log:
             raise RuntimeError("only logs are allowed to be emptied by this interface!")
         # ask for confirmation
         if input("Purge all logs? [y/n]") != "y":
@@ -31,8 +31,8 @@ class TableManager:
 
     def all(self):
         """Retrieve all entries"""
-        return sql.select_all(self.session, self.table_name)
+        return sql.select_all(self.session, self.table_object)
 
     def get(self, hash_partial):
         """Retrieve an entry"""
-        return sql.select_hash(self.session, self.table_name, hash_partial)
+        return sql.select_hash(self.session, self.table_object, hash_partial)

--- a/src/banana/navigator/table_manager.py
+++ b/src/banana/navigator/table_manager.py
@@ -35,6 +35,4 @@ class TableManager:
 
     def get(self, hash_partial):
         """Retrieve an entry"""
-        return sql.select_hash(
-            self.session, self.table_name, bytes.fromhex(hash_partial)
-        )
+        return sql.select_hash(self.session, self.table_name, hash_partial)

--- a/src/banana/navigator/table_manager.py
+++ b/src/banana/navigator/table_manager.py
@@ -9,14 +9,14 @@ class TableManager:
 
     Parameters
     ----------
-        conn : sqlite3.Connection
-            DB connection
-        table_name : str
-            table name
+    session : sqlalchemy.orm.session.Session
+        DB ORM session
+    table_name : str
+        table name
     """
 
-    def __init__(self, conn, table_name):
-        self.conn = conn
+    def __init__(self, session, table_name):
+        self.session = session
         self.table_name = table_name
 
     def truncate(self):
@@ -31,8 +31,10 @@ class TableManager:
 
     def all(self):
         """Retrieve all entries"""
-        return sql.select_all(self.conn, self.table_name)
+        return sql.select_all(self.session, self.table_name)
 
     def get(self, hash_partial):
         """Retrieve an entry"""
-        return sql.select_hash(self.conn, self.table_name, bytes.fromhex(hash_partial))
+        return sql.select_hash(
+            self.session, self.table_name, bytes.fromhex(hash_partial)
+        )


### PR DESCRIPTION
Start implementing a better data handling.

Proposal:
- every python object that goes in the db should implement `to_document()/from_document()` methods
- they go through a dictionary representation while dumping and loading
  - the dictionary is fully flexible and can host representation for almost any object (we're not going to store functions anyhow, however in principle they can be stored as their source code)
  - the dict values should be elementary types, like int, float and str
  - better: they can store even other dict, i.e. the leafs have to scalar and elementary

(later we can think about doing it recursively, for the time being the `to_document()` should immediately generate a json-like dict)

The dictionaries will be stored in the db as bytes, this can be done in any way (at this point there should be no problem using `pickle`, but if there is any we can use `json` to a string, and string to bytes).