### PR TITLE
adding new keys to theory template

### DIFF
--- a/src/banana/data/theory_template.yaml
+++ b/src/banana/data/theory_template.yaml
@@ -47,3 +47,5 @@ global_nx: 0
 EScaleVar: 1
 ModSV: null
 n3lo_ad_variation: [0,0,0,0]
+n3lo_cf_variation: 0
+FONLLParts: "full"


### PR DESCRIPTION
Adding two missing keys to the theory template: `FONLLparts` and `n3lo_cf_variation`